### PR TITLE
Update clang_format.yml version from 15 to 18

### DIFF
--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -33,6 +33,6 @@ jobs:
     - name: Run clang-format style check for C/C++/Protobuf programs.
       uses: jidicula/clang-format-action@v4.10.1
       with:
-        clang-format-version: '15'
+        clang-format-version: '18'
         check-path: ${{ matrix.path['check'] }}
         exclude-regex: ${{ matrix.path['exclude'] }}


### PR DESCRIPTION
Bump up version of clang format used from 15 to 18. Out current CI fails even when code is formatted correctly because the code output by clang format varies from version to version. Version 18 is the latest that is available with brew, and can be obtained on ubuntu (by jumping through a few hoops).