### PR TITLE
add ability to specify delimiter for CSV inputs

### DIFF
--- a/scripts/air_quality/evolve_aq.sh
+++ b/scripts/air_quality/evolve_aq.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# This is a script for evlolving networks to predict Air Quality data
+# This also doubles as an example for the csv delimiter option
+
+cd build
+
+INPUT_PARAMETERS="Date Time PT08.S1(CO) PT08.S2(NMHC) PT08.S3(NOx) PT08.S4(NO2) PT08.S5(O3) T RH AH"
+OUTPUT_PARAMETERS="CO(GT) NO2(GT) NOx(GT) NMHC(GT)"
+
+exp_name="/home/aidan/sandbox/DEEPSPrj/output/init_mvar_2"
+mkdir -p $exp_name
+echo "Running base EXAMM code with UCI Air Quality dataset, results will be saved to: "$exp_name
+echo "###-------------------###"
+
+../../build/multithreaded/examm_mt \
+--training_filenames /home/aidan/sandbox/DEEPSPrj/data/AirQualityUCI.csv \
+--test_filenames /home/aidan/sandbox/DEEPSPrj/data/AirQualityUCI.csv \
+--time_offset 1 \
+--input_parameter_names $INPUT_PARAMETERS \
+--output_parameter_names $OUTPUT_PARAMETERS \
+--number_islands 10 \
+--island_size 10 \
+--max_genomes 20000 \
+--number_threads 14 \
+--bp_iterations 15 \
+--normalize min_max \
+--output_directory $exp_name \
+--possible_node_types simple UGRNN MGU GRU delta LSTM \
+--std_message_level INFO \
+--file_message_level NONE \
+--csv_delimiter ";"

--- a/time_series/time_series.cxx
+++ b/time_series/time_series.cxx
@@ -238,7 +238,7 @@ void TimeSeriesSet::add_time_series(string name) {
     }
 }
 
-TimeSeriesSet::TimeSeriesSet(string _filename, const vector<string>& _fields) {
+TimeSeriesSet::TimeSeriesSet(string _filename, const vector<string>& _fields, char delim) {
     filename = _filename;
     fields = _fields;
 
@@ -251,7 +251,7 @@ TimeSeriesSet::TimeSeriesSet(string _filename, const vector<string>& _fields) {
     }
 
     vector<string> file_fields;
-    string_split(line, ',', file_fields);
+    string_split(line, delim, file_fields);
     for (int32_t i = 0; i < (int32_t) file_fields.size(); i++) {
         // get rid of carriage returns (sometimes windows messes this up)
         file_fields[i].erase(std::remove(file_fields[i].begin(), file_fields[i].end(), '\r'), file_fields[i].end());
@@ -308,7 +308,7 @@ TimeSeriesSet::TimeSeriesSet(string _filename, const vector<string>& _fields) {
         }
 
         vector<string> parts;
-        string_split(line, ',', parts);
+        string_split(line, delim, parts);
 
         if (parts.size() != file_fields.size()) {
             Log::fatal(
@@ -734,7 +734,7 @@ void TimeSeriesSets::load_time_series() {
     for (int32_t i = 0; i < (int32_t) filenames.size(); i++) {
         Log::info("\t%s\n", filenames[i].c_str());
 
-        TimeSeriesSet* ts = new TimeSeriesSet(filenames[i], all_parameter_names);
+        TimeSeriesSet* ts = new TimeSeriesSet(filenames[i], all_parameter_names, this->csv_delimiter);
         time_series.push_back(ts);
 
         rows += ts->get_number_rows();
@@ -829,6 +829,25 @@ TimeSeriesSets* TimeSeriesSets::generate_from_arguments(const vector<string>& ar
         );
         help_message();
         exit(1);
+    }
+
+    if (argument_exists(arguments, "--csv_delimiter")) {
+        vector<string> delim_vec;
+        get_argument_vector(arguments, "--csv_delimiter", false, delim_vec);
+
+        string delim_str = delim_vec.front();
+
+        if (delim_vec.size() != 1 || delim_str.size() != 1) {
+            // Exit if the user specifies more than one delimiter character
+            Log::fatal(
+                "The delimeter for CSV files should be a single character."
+            );
+
+            help_message();
+            exit(1);
+        }
+
+        tss->csv_delimiter = delim_str.at(0);
     }
 
     tss->load_time_series();

--- a/time_series/time_series.hxx
+++ b/time_series/time_series.hxx
@@ -72,7 +72,7 @@ class TimeSeriesSet {
     TimeSeriesSet();
 
    public:
-    TimeSeriesSet(string _filename, const vector<string>& _fields);
+    TimeSeriesSet(string _filename, const vector<string>& _fields, char delim);
     ~TimeSeriesSet();
     void add_time_series(string name);
 
@@ -115,6 +115,8 @@ class TimeSeriesSet {
 
 class TimeSeriesSets {
    private:
+    char csv_delimiter = ',';
+
     string normalize_type;
 
     vector<string> filenames;


### PR DESCRIPTION
## Describe your changes
Added support for other delimiters besides ',' in CSV files fed into EXAMM. This is especially useful when the input data has other delimiters such as tabs (which is really a TSV file) or semicolons. 

## What type is this change?
- [ ] Bug fix
- [X] New feature

## Checklist before requesting a review
- [X] My code follows the style guidelines of this project
- [] I have tested on MAC OS system 
- [X] I have tested on Arch Linux system
- [ ] I have tested on the RIT research cluster and updated the spack packages for compiling
- [ ] My changes generate no new warnings
- [ ] If the PR is related to a new feature, I added the running scripts for the new feature 

## How Has This Been Tested?
Evolved genomes on the UCI air quality dataset which uses semicolons as delimiters.
