### PR TITLE
update get_number_weights_enabled_hidden_layer_node method

### DIFF
--- a/examm/examm.hxx
+++ b/examm/examm.hxx
@@ -82,14 +82,11 @@ class EXAMM {
 
     bool generate_op_log;
     bool generate_visualization_json;
+
+    int32_t growth_phase_genomes;
+    int32_t reduction_phase_genomes;
     // size log check
     int32_t genome_size_log;
-
-    int32_t growth_phase_genomes;
-    int32_t reduction_phase_genomes;
-
-    int32_t growth_phase_genomes;
-    int32_t reduction_phase_genomes;
 
    public:
     EXAMM(

--- a/rnn/rnn_genome.cxx
+++ b/rnn/rnn_genome.cxx
@@ -656,11 +656,15 @@ int32_t RNN_Genome::get_number_weights_enabled_hidden_layer_node() {
     }
 
     for (int32_t i = 0; i < (int32_t) edges.size(); i++) {
-        number_weights++;
+        if (edges[i]->enabled) {
+            number_weights++;
+        }
     }
 
     for (int32_t i = 0; i < (int32_t) recurrent_edges.size(); i++) {
-        number_weights++;
+        if (recurrent_edges[i]->enabled) {
+            number_weights++;
+        }
     }
 
     return number_weights;


### PR DESCRIPTION
## Describe your changes
Update the code to count only the enabled weights of edges,rec edges and hidden layer node
## What type is this change?
- [x] Bug fix
- [ ] New feature

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have tested on MAC OS system 
- [ ] I have tested on Ubuntu system
- [ ] I have tested on the RIT research cluster and updated the spack packages for compiling
- [x] My changes generate no new warnings
- [ ] If the PR is related to a new feature, I added the running scripts for the new feature

## How Has This Been Tested?

I have tested it by generating the txt versions of genomes and counting the stats in the csv file generated for generated genome.