### PR TITLE
Harden loss functions and raise evaluation rigor

### DIFF
--- a/financial_loss_functions/scripts/run_multi_train.py
+++ b/financial_loss_functions/scripts/run_multi_train.py
@@ -103,6 +103,7 @@ def run_multi_train(
     n_runs: int = 5,
     seeds: list[int] | None = None,
     rank_metric: str = "sharpe",
+    resume: bool = False,
 ):
     """
     Train *model_name* with *loss_name* for *n_runs* seeds.
@@ -141,8 +142,10 @@ def run_multi_train(
     # Multi-run specific dirs
     best_models_dir = artifacts_paths["results_dir"] / "best_models"
     multi_run_dir = artifacts_paths["results_dir"] / "multi_run"
+    checkpoints_root = artifacts_paths["results_dir"] / "checkpoints"
     create_directory(best_models_dir)
     create_directory(multi_run_dir)
+    create_directory(checkpoints_root)
 
     # ── Register models & losses ──────────────────────────────
     models_module = paths_config["models_module"]
@@ -258,8 +261,18 @@ def run_multi_train(
                 device=torch_device,
             )
 
-            # Train with validation
-            trainer.train(train_ds, val_ds)
+            # Per-seed checkpoint directory.
+            run_ckpt_dir = checkpoints_root / f"{model_name}-{loss_name}-seed{seed}"
+            create_directory(run_ckpt_dir)
+
+            # If resuming, pick up from the most recent checkpoint for this seed.
+            if resume:
+                latest = Trainer.find_latest_checkpoint(str(run_ckpt_dir))
+                if latest is not None:
+                    trainer.resume_from(latest)
+
+            # Train with validation, writing checkpoints along the way.
+            trainer.train(train_ds, val_ds, checkpoint_dir=str(run_ckpt_dir))
             # Evaluate to get allocation weights
             trainer.evaluate(val_ds)
             alloc_weights = trainer.get_eval_alloc_weights()
@@ -399,6 +412,12 @@ if __name__ == "__main__":
             choices=["sharpe", "sortino", "max_drawdown", "cvar", "omega", "calmar"],
             help="Metric used to rank runs and pick the best (default: sharpe).",
         )
+        parser.add_argument(
+            "--resume", action="store_true",
+            help="If set, resume each per-seed run from the latest checkpoint on disk "
+                 "(if any). Checkpoint frequency is controlled by "
+                 "hparams.json > nn_models[model].train.checkpoint_every.",
+        )
 
         args = parser.parse_args()
 
@@ -412,6 +431,7 @@ if __name__ == "__main__":
             n_runs=args.n_runs,
             seeds=seed_list,
             rank_metric=args.rank_metric,
+            resume=args.resume,
         )
 
     except SystemExit:

--- a/financial_loss_functions/src/evaluation/evaluator.py
+++ b/financial_loss_functions/src/evaluation/evaluator.py
@@ -2,6 +2,8 @@ import numpy as np
 import pandas as pd
 from typing import Callable
 
+from cvxopt import matrix, solvers
+
 class Evaluator:
     """
     Class to evaulate and compare all generated weights from all models/methods,
@@ -49,7 +51,7 @@ class Evaluator:
             
             # Returns for each window
             self.all_daily_returns = {} # Add all returns for every window
-        
+
         else:
             if all_daily_returns is None:
                 raise ValueError(
@@ -59,6 +61,11 @@ class Evaluator:
                 self.eval_returns = None
                 self.ba_eval = None
                 self.all_daily_returns = all_daily_returns
+
+        # Per-strategy allocation weights, keyed by model name. Populated by
+        # calc_pf_daily_rets so turnover and cost-adjusted returns can be derived
+        # later without recomputing them from the model.
+        self.all_weights: dict[str, np.ndarray] = {}
 
         self.metrics_lib = metrics_lib
     
@@ -135,6 +142,9 @@ class Evaluator:
                     pf_daily_returns.append(daily_returns) # Shape: (50,)
              
             self.all_daily_returns[model_name] = np.array(pf_daily_returns)
+            # Cache the raw weights so turnover and cost-adjusted returns can be
+            # derived per strategy without rerunning the model.
+            self.all_weights[model_name] = np.asarray(eval_weights)
         else:
             print(
                 f'DEBUG: Evaluation weights array must have only 2 dims, got {eval_weights.ndim}.'
@@ -157,6 +167,76 @@ class Evaluator:
         Add benchmark returns for the respective evalulation output windows. eg., S&P500 daily returns
         """
         self.all_daily_returns.update({bench_name: bench_rets})
+
+    def add_benchmark_weights(self, bench_name: str, weights: np.ndarray):
+        """
+        Attach per-window weights for a benchmark/strategy whose daily returns
+        were added separately (e.g. classical calculators like MinVariance).
+        Enables turnover and cost-adjusted returns for that strategy.
+        """
+        if weights.ndim != 2:
+            raise ValueError(
+                f"add_benchmark_weights: expected 2D (num_windows, N), got {weights.ndim}D."
+            )
+        self.all_weights[bench_name] = np.asarray(weights)
+
+    def calc_turnover_for_all(self) -> pd.Series:
+        """
+        Per-strategy mean one-way turnover across consecutive windows, using
+        cached weights. Strategies with no cached weights (benchmark returns
+        added via add_benchmark_rets without weights) are skipped.
+
+        Returns:
+            pd.Series indexed by strategy name.
+        """
+        from src.evaluation.metrics import turnover as _turnover
+
+        if not self.all_weights:
+            print('No weights cached; nothing to compute turnover for.')
+            return pd.Series(dtype=float)
+
+        out = {name: float(_turnover(w)) for name, w in self.all_weights.items()}
+        return pd.Series(out, name="turnover")
+
+    def calc_cost_adjusted_daily_rets(
+            self, model_name: str, cost_bps: float = 10.0
+        ) -> np.ndarray:
+        """
+        Return a copy of `model_name`'s per-window daily returns with a uniform
+        transaction cost charged on the first day of each window, proportional
+        to the one-way turnover relative to the previous window.
+
+        Unlike the bid-ask path in calc_pf_daily_rets (which needs per-asset
+        spreads), this method applies a single round-trip cost assumption
+        expressed in basis points of gross traded notional.
+
+        Args:
+            model_name (str): strategy whose weights have been cached.
+            cost_bps (float): one-way transaction cost in basis points applied
+                to L1 turnover (default 10 bps = 0.10 %).
+
+        Returns:
+            np.ndarray of shape (num_windows, T) — a fresh copy, not in-place.
+
+        Raises:
+            KeyError: if weights or daily returns for `model_name` are missing.
+        """
+        if model_name not in self.all_weights:
+            raise KeyError(f"No cached weights for '{model_name}'. Run calc_pf_daily_rets first.")
+        if model_name not in self.all_daily_returns:
+            raise KeyError(f"No cached daily returns for '{model_name}'.")
+
+        weights = self.all_weights[model_name]                  # (num_windows, N)
+        daily_returns = np.array(self.all_daily_returns[model_name], copy=True)
+        cost_rate = float(cost_bps) / 1e4
+
+        prev = None
+        for i in range(weights.shape[0]):
+            delta = weights[i] if prev is None else np.abs(weights[i] - prev)
+            cost = cost_rate * delta.sum()
+            daily_returns[i] = self._calc_net_returns(daily_returns[i], cost)
+            prev = weights[i]
+        return daily_returns
 
     def _daily_rets_calcd_check(self):
         if not self.all_daily_returns:
@@ -194,6 +274,71 @@ class Evaluator:
         else:
             return pd.DataFrame(metric_perfomances)
     
+    def calc_metric_performance_ci(
+            self,
+            metric_func: Callable,
+            n_boot: int = 1000,
+            ci: float = 0.95,
+            seed: int | None = None,
+        ) -> pd.DataFrame:
+        """
+        For each stored strategy, flatten all windows into a single daily-return
+        series and report bootstrap point / lower / upper / p-value.
+
+        Uses the stationary bootstrap (Politis & Romano, 1994) so short-range
+        serial correlation in daily returns is preserved.
+
+        Args:
+            metric_func (Callable): scalar metric mapping (T,)-array → float.
+            n_boot (int): bootstrap resamples per strategy.
+            ci (float): two-sided coverage.
+            seed (int | None): RNG seed (None = non-reproducible draws).
+
+        Returns:
+            pd.DataFrame indexed by strategy name with columns
+            ['point', 'lower', 'upper', 'p_value_gt_zero'].
+        """
+        from src.evaluation.metrics import bootstrap_metric_ci
+
+        self._daily_rets_calcd_check()
+
+        rows = {}
+        for model, all_rets in self.all_daily_returns.items():
+            flat = np.asarray(all_rets).flatten()
+            rows[model] = bootstrap_metric_ci(
+                flat, metric_func,
+                n_boot=n_boot, ci=ci, seed=seed,
+            )
+        return pd.DataFrame.from_dict(rows, orient="index")
+
+    def calc_paired_diff_ci(
+            self,
+            model_a: str,
+            model_b: str,
+            metric_func: Callable,
+            n_boot: int = 1000,
+            ci: float = 0.95,
+            seed: int | None = None,
+        ) -> dict:
+        """
+        Bootstrap CI for metric(model_a) - metric(model_b). Positive lower bound
+        on the CI is the usual "A significantly beats B" claim.
+        """
+        from src.evaluation.metrics import bootstrap_paired_diff_ci
+
+        self._daily_rets_calcd_check()
+        if model_a not in self.all_daily_returns:
+            raise KeyError(f"No daily returns stored for '{model_a}'")
+        if model_b not in self.all_daily_returns:
+            raise KeyError(f"No daily returns stored for '{model_b}'")
+
+        a = np.asarray(self.all_daily_returns[model_a]).flatten()
+        b = np.asarray(self.all_daily_returns[model_b]).flatten()
+        return bootstrap_paired_diff_ci(
+            a, b, metric_func,
+            n_boot=n_boot, ci=ci, seed=seed,
+        )
+
     def calc_avg_performance(self) -> pd.DataFrame | None:
         
         if self.metrics_lib:
@@ -288,6 +433,165 @@ class EqualWeightCalculator:
                 'Run `EqualWeightCalculator.calc_eq_wt_daily_rets()` first.'
             )
             return None
+
+class MinVarianceCalculator:
+    """
+    Classical long-only minimum-variance benchmark.
+
+    For each evaluation window, solves
+        min  w^T Σ w
+        s.t. sum(w) = 1, w >= 0
+    where Σ is the sample covariance of in-window returns. The resulting weights
+    are then applied to the *same* window's returns to produce daily returns,
+    matching the out-of-sample convention already used by EqualWeightCalculator.
+    """
+
+    def __init__(self, eval_returns: np.ndarray, shrink: float = 0.0):
+        """
+        Args:
+            eval_returns (np.ndarray): (num_windows, T, N) out-of-sample return windows.
+            shrink (float): Optional linear shrinkage of Σ toward a scaled identity,
+                cov_shrunk = (1-s)·cov + s·(tr(cov)/N)·I. Default = 0 (no shrinkage).
+        """
+        if eval_returns.ndim != 3:
+            raise ValueError(
+                f"MinVarianceCalculator: eval_returns must be 3D, got {eval_returns.ndim}D."
+            )
+        if not (0.0 <= shrink < 1.0):
+            raise ValueError(f"shrink must be in [0, 1), got {shrink}")
+        self.eval_returns = eval_returns
+        self.shrink = shrink
+        self.weights: np.ndarray | None = None
+        self.daily_returns: np.ndarray | None = None
+
+    @staticmethod
+    def _solve_long_only_min_var(cov: np.ndarray) -> np.ndarray:
+        """Solve the standard simplex-constrained min-variance QP via cvxopt."""
+        N = cov.shape[0]
+        # cvxopt solves: min 0.5 x^T P x + q^T x  s.t. Gx <= h, Ax = b.
+        P = matrix(cov.astype(np.float64))
+        q = matrix(np.zeros(N))
+        G = matrix(-np.eye(N))          # -x <= 0  => x >= 0
+        h = matrix(np.zeros(N))
+        A = matrix(np.ones((1, N)))     # sum(x) == 1
+        b = matrix(np.ones(1))
+        solvers.options["show_progress"] = False
+        sol = solvers.qp(P, q, G, h, A, b)
+        w = np.array(sol["x"]).flatten()
+        # Tiny negative values can slip through; clamp and renormalize.
+        w = np.clip(w, 0.0, None)
+        s = w.sum()
+        return w / s if s > 0 else np.full(N, 1.0 / N)
+
+    def _shrink_cov(self, cov: np.ndarray) -> np.ndarray:
+        if self.shrink <= 0.0:
+            return cov
+        N = cov.shape[0]
+        target = (np.trace(cov) / N) * np.eye(N)
+        return (1.0 - self.shrink) * cov + self.shrink * target
+
+    def calc_min_var_daily_rets(self) -> np.ndarray:
+        """
+        For each window, fit Σ on the window's returns, solve for min-var weights,
+        and produce the per-step portfolio returns on the same window. Stores and
+        returns an array of shape (num_windows, T).
+        """
+        num_windows = self.eval_returns.shape[0]
+        weights_per_window = []
+        daily_returns_per_window = []
+
+        for i in range(num_windows):
+            window = self.eval_returns[i]                # (T, N)
+            cov = np.cov(window, rowvar=False)           # (N, N)
+            cov = self._shrink_cov(cov)
+            w = self._solve_long_only_min_var(cov)       # (N,)
+            weights_per_window.append(w)
+            daily_returns_per_window.append(window @ w) # (T,)
+
+        self.weights = np.stack(weights_per_window, axis=0)       # (num_windows, N)
+        self.daily_returns = np.stack(daily_returns_per_window)   # (num_windows, T)
+        return self.daily_returns
+
+    def get_weights(self) -> np.ndarray | None:
+        return self.weights
+
+
+class EqualRiskContribCalculator:
+    """
+    Classical Equal-Risk-Contribution (ERC) / risk-parity benchmark.
+
+    For each evaluation window, finds long-only weights where each asset
+    contributes equally to portfolio variance:
+        RC_i = w_i · (Σ w)_i   must all equal σ_p^2 / N.
+
+    Uses the iterative fixed-point update from Maillard, Roncalli & Teiletche
+    (2010), which is simple, monotonic, and robust enough for small N.
+    """
+
+    def __init__(
+        self,
+        eval_returns: np.ndarray,
+        shrink: float = 0.0,
+        max_iter: int = 500,
+        tol: float = 1e-8,
+    ):
+        if eval_returns.ndim != 3:
+            raise ValueError(
+                f"EqualRiskContribCalculator: eval_returns must be 3D, got {eval_returns.ndim}D."
+            )
+        if not (0.0 <= shrink < 1.0):
+            raise ValueError(f"shrink must be in [0, 1), got {shrink}")
+        self.eval_returns = eval_returns
+        self.shrink = shrink
+        self.max_iter = max_iter
+        self.tol = tol
+        self.weights: np.ndarray | None = None
+        self.daily_returns: np.ndarray | None = None
+
+    @staticmethod
+    def _solve_erc(cov: np.ndarray, max_iter: int, tol: float) -> np.ndarray:
+        """Maillard-Roncalli-Teiletche fixed-point iteration for ERC weights."""
+        N = cov.shape[0]
+        w = np.full(N, 1.0 / N)
+        for _ in range(max_iter):
+            mrc = cov @ w                         # marginal risk contributions (N,)
+            # Target step: w_i ∝ 1 / mrc_i (so w_i · mrc_i is equalized).
+            mrc_safe = np.where(mrc > 0, mrc, 1e-12)
+            w_new = 1.0 / mrc_safe
+            w_new = w_new / w_new.sum()
+            if np.max(np.abs(w_new - w)) < tol:
+                w = w_new
+                break
+            w = w_new
+        return w
+
+    def _shrink_cov(self, cov: np.ndarray) -> np.ndarray:
+        if self.shrink <= 0.0:
+            return cov
+        N = cov.shape[0]
+        target = (np.trace(cov) / N) * np.eye(N)
+        return (1.0 - self.shrink) * cov + self.shrink * target
+
+    def calc_erc_daily_rets(self) -> np.ndarray:
+        num_windows = self.eval_returns.shape[0]
+        weights_per_window = []
+        daily_returns_per_window = []
+
+        for i in range(num_windows):
+            window = self.eval_returns[i]
+            cov = np.cov(window, rowvar=False)
+            cov = self._shrink_cov(cov)
+            w = self._solve_erc(cov, self.max_iter, self.tol)
+            weights_per_window.append(w)
+            daily_returns_per_window.append(window @ w)
+
+        self.weights = np.stack(weights_per_window, axis=0)
+        self.daily_returns = np.stack(daily_returns_per_window)
+        return self.daily_returns
+
+    def get_weights(self) -> np.ndarray | None:
+        return self.weights
+
 
 def filter_models(
         avg_perf: pd.DataFrame, bench_name: str, bench_met: str, keep: list[str]

--- a/financial_loss_functions/src/evaluation/metrics.py
+++ b/financial_loss_functions/src/evaluation/metrics.py
@@ -144,5 +144,158 @@ def omega(returns_arr: np.ndarray, threshold: float = 0.0) -> np.float64:
 def calmar(returns_arr: np.ndarray) -> np.float64:
     """Ratio of annualized return to maximum drawdown."""
     mdd = abs(max_drawdown(returns_arr))
-    
+
     return np.mean(returns_arr) / mdd if mdd != 0 else 0.0
+
+@MetricLibrary.register()
+def turnover(weights: np.ndarray) -> np.float64:
+    """
+    Average one-way L1 turnover across consecutive windows: mean_t( 0.5 * ||w_t - w_{t-1}||_1 ).
+
+    Args:
+        weights (np.ndarray): (num_windows, N) per-window allocation weights.
+
+    Returns:
+        float: Mean per-step turnover (0 = never trade, 1 = rotate the whole book each step).
+            Returns 0.0 if fewer than two windows are provided.
+    """
+    if weights.ndim != 2:
+        raise ValueError(f"turnover expects 2D (num_windows, N), got {weights.ndim}D.")
+    if weights.shape[0] < 2:
+        return np.float64(0.0)
+    deltas = np.abs(np.diff(weights, axis=0)).sum(axis=1) * 0.5  # (num_windows-1,)
+    return np.mean(deltas)
+
+
+# ─────────────────────────── Bootstrap CI helpers ───────────────────────────
+
+def _stationary_bootstrap_indices(
+    n: int, block_mean_len: float, rng: np.random.Generator
+) -> np.ndarray:
+    """
+    Politis & Romano (1994) stationary bootstrap indices.
+
+    Draws `n` indices by chaining geometric-length blocks (mean = block_mean_len)
+    sampled from the original series. Preserves short-range autocorrelation
+    better than i.i.d. resampling while staying stationary.
+    """
+    if n <= 0:
+        return np.empty(0, dtype=int)
+    if block_mean_len < 1.0:
+        block_mean_len = 1.0
+    p = 1.0 / block_mean_len  # per-step probability of starting a new block
+    idx = np.empty(n, dtype=int)
+    idx[0] = rng.integers(0, n)
+    restart = rng.random(n) < p
+    for t in range(1, n):
+        if restart[t]:
+            idx[t] = rng.integers(0, n)
+        else:
+            idx[t] = (idx[t - 1] + 1) % n
+    return idx
+
+
+def bootstrap_metric_ci(
+    daily_returns: np.ndarray,
+    metric_fn: Callable,
+    n_boot: int = 1000,
+    ci: float = 0.95,
+    block_mean_len: float | None = None,
+    seed: int | None = None,
+) -> dict:
+    """
+    Block-bootstrap confidence interval for a scalar metric on a daily-return series.
+
+    Args:
+        daily_returns (np.ndarray): (T,) series of daily returns.
+        metric_fn (Callable): function mapping (T,)-array → scalar (e.g. sharpe).
+        n_boot (int): number of bootstrap resamples. Default = 1000.
+        ci (float): two-sided coverage in (0, 1). Default = 0.95.
+        block_mean_len (float | None): mean block length for the stationary bootstrap.
+            If None, defaults to sqrt(T) — a common rule of thumb for daily data.
+        seed (int | None): RNG seed for reproducibility.
+
+    Returns:
+        dict with keys 'point' (metric on the full series), 'lower', 'upper'
+        (empirical percentile CI), and 'p_value_gt_zero' (fraction of bootstrap
+        estimates that are ≤ 0; a small value means "metric > 0" is well-supported).
+    """
+    daily_returns = np.asarray(daily_returns).flatten()
+    T = daily_returns.shape[0]
+    if T < 2:
+        raise ValueError("bootstrap_metric_ci needs at least 2 observations.")
+    if not (0.0 < ci < 1.0):
+        raise ValueError(f"ci must be in (0, 1), got {ci}")
+    if block_mean_len is None:
+        block_mean_len = float(np.sqrt(T))
+
+    rng = np.random.default_rng(seed)
+    point = float(metric_fn(daily_returns))
+
+    boots = np.empty(n_boot, dtype=np.float64)
+    for b in range(n_boot):
+        idx = _stationary_bootstrap_indices(T, block_mean_len, rng)
+        boots[b] = float(metric_fn(daily_returns[idx]))
+
+    # Replace non-finite bootstrap draws (e.g. sortino's inf when no downside) with NaN
+    # so they drop out of the percentile computation cleanly.
+    finite = np.isfinite(boots)
+    if not finite.any():
+        return {"point": point, "lower": np.nan, "upper": np.nan, "p_value_gt_zero": np.nan}
+    draws = boots[finite]
+
+    alpha = 1.0 - ci
+    lower = float(np.quantile(draws, alpha / 2.0))
+    upper = float(np.quantile(draws, 1.0 - alpha / 2.0))
+    p_value = float(np.mean(draws <= 0.0))
+
+    return {"point": point, "lower": lower, "upper": upper, "p_value_gt_zero": p_value}
+
+
+def bootstrap_paired_diff_ci(
+    daily_returns_a: np.ndarray,
+    daily_returns_b: np.ndarray,
+    metric_fn: Callable,
+    n_boot: int = 1000,
+    ci: float = 0.95,
+    block_mean_len: float | None = None,
+    seed: int | None = None,
+) -> dict:
+    """
+    Paired block-bootstrap CI for metric(a) - metric(b), using *the same* resampling
+    indices for both series so the draws are matched in time.
+
+    Useful for claims like "strategy A has a significantly higher Sharpe than B".
+    """
+    a = np.asarray(daily_returns_a).flatten()
+    b = np.asarray(daily_returns_b).flatten()
+    if a.shape != b.shape:
+        raise ValueError(
+            f"paired bootstrap requires equal-length series, got {a.shape} vs {b.shape}"
+        )
+    T = a.shape[0]
+    if T < 2:
+        raise ValueError("bootstrap_paired_diff_ci needs at least 2 observations.")
+    if block_mean_len is None:
+        block_mean_len = float(np.sqrt(T))
+
+    rng = np.random.default_rng(seed)
+    point = float(metric_fn(a) - metric_fn(b))
+
+    boots = np.empty(n_boot, dtype=np.float64)
+    for i in range(n_boot):
+        idx = _stationary_bootstrap_indices(T, block_mean_len, rng)
+        boots[i] = float(metric_fn(a[idx]) - metric_fn(b[idx]))
+
+    finite = np.isfinite(boots)
+    if not finite.any():
+        return {"point": point, "lower": np.nan, "upper": np.nan, "p_value_a_gt_b": np.nan}
+    draws = boots[finite]
+
+    alpha = 1.0 - ci
+    lower = float(np.quantile(draws, alpha / 2.0))
+    upper = float(np.quantile(draws, 1.0 - alpha / 2.0))
+    # one-sided p-value for H1: metric(a) > metric(b)
+    p_value = float(np.mean(draws <= 0.0))
+
+    return {"point": point, "lower": lower, "upper": upper, "p_value_a_gt_b": p_value}

--- a/financial_loss_functions/src/training/loss_functions.py
+++ b/financial_loss_functions/src/training/loss_functions.py
@@ -132,8 +132,8 @@ def log_return_objective(port_returns: Tensor, eps: float = 1e-8, **kwargs
             (-ve because NN should maximize +ve returns but minimize loss). 
     """
     # Convert to log returns: log(1 + R)
-    # We add a tiny epsilon to avoid log(0) if a portfolio hits -100%
-    log_returns = torch.log(1.0 + port_returns + eps)
+    # Clamp the argument to >= eps so returns near -100% cannot produce log of a non-positive number.
+    log_returns = torch.log(torch.clamp(1.0 + port_returns, min=eps))
     
     # Sum of log returns = Cumulative log growth
     cum_log_return = log_returns.sum(dim=1)
@@ -232,6 +232,8 @@ def smooth_neglog_sharpe_loss(
         Tensor: Batch mean smooth negative log Sharpe ratio objective
             (-ve because NN should maximize +ve returns but minimize loss).
     """
+    if beta <= 0:
+        raise ValueError(f"smooth_neglog_sharpe_loss: beta must be > 0, got {beta}")
     mean_ret = pf_returns.mean(dim=1)
 
     var = pf_returns.var(dim=1)
@@ -263,11 +265,11 @@ def log_sharpe_objective(pf_returns: Tensor, eps: float = 1e-8, **kwargs) -> Ten
             (-ve because NN should maximize +ve returns but minimize loss). 
     """
 
-    log_returns = torch.log(1.0 + pf_returns + eps)
-    
+    log_returns = torch.log(torch.clamp(1.0 + pf_returns, min=eps))
+
     mean_log_ret = log_returns.mean(dim=1)
     var_log  = log_returns.var(dim=1)          # variance, not std
-    
+
     return -(mean_log_ret / (var_log.sqrt() + eps)).mean()
 
 # -------------------- Sortino -------------------- #
@@ -393,6 +395,8 @@ def smooth_neglog_sortino_objective(
         Tensor: Batch mean smooth negative log Sharpe ratio objective
             (-ve because NN should maximize +ve returns but minimize loss).
     """
+    if use_soft_downside and beta <= 0:
+        raise ValueError(f"smooth_neglog_sortino_objective: beta must be > 0, got {beta}")
     # downside: smooth or hard
     if use_soft_downside:
         # softplus approximates clamp(target - port, min=0)
@@ -436,8 +440,10 @@ def log_sortino_objective(
         Tensor: Batch mean log Sortino ratio objective
             (-ve because NN should maximize +ve returns but minimize loss).
     """
-    # Log portfolio returns
-    log_returns = torch.log(1.0 + pf_returns + eps)
+    if use_soft_downside and beta <= 0:
+        raise ValueError(f"log_sortino_objective: beta must be > 0, got {beta}")
+    # Log portfolio returns (clamp arg to >= eps so returns near -100% don't blow up)
+    log_returns = torch.log(torch.clamp(1.0 + pf_returns, min=eps))
 
     # Downside deviation: std of negative deviations from target
     # downside: smooth or hard
@@ -487,6 +493,8 @@ def smooth_mdd_regularizer(
     Return:
         Tensor: batch mean smooth max drawdown regularizer.
     """
+    if temp <= 0:
+        raise ValueError(f"smooth_mdd_regularizer: temp must be > 0, got {temp}")
     B, T = pf_returns.shape
 
     # clamp port to > -1 for log1p safety
@@ -580,9 +588,11 @@ def smooth_cvar_regularizer(
             'Tail Ratio' to convert CVaR into a unitless ratio.
         port_std_floor (float): Minimum floor clamp and portfolio standard deviation.
             
-    Returns: 
+    Returns:
         Tensor: Batch mean smooth CVaR regularizer term
     """
+    if temp <= 0:
+        raise ValueError(f"smooth_cvar_regularizer: temp must be > 0, got {temp}")
     losses = -pf_returns  # (B, T)
 
     if scale_by_std:
@@ -631,12 +641,16 @@ def smooth_rockafellar_cvar_regularizer(
             'Tail Ratio' to convert CVaR into a unitless ratio.
         port_std_floor (float): Minimum floor clamp and portfolio standard deviation.
             
-    Returns: 
+    Returns:
         Tensor: Batch mean differentiable Rockafellar & Uryasev CVaR regularizer term
     """
+    if temp <= 0:
+        raise ValueError(f"smooth_rockafellar_cvar_regularizer: temp must be > 0, got {temp}")
+    if not (0 < alpha <= 1):
+        raise ValueError(f"smooth_rockafellar_cvar_regularizer: alpha must be in (0, 1], got {alpha}")
     # Calculate Portfolio Returns and Losses
     # port: (B, T), losses: (B, T)
-    losses = -pf_returns 
+    losses = -pf_returns
 
     # Estimate VaR (zeta) for the batch
     # We take the (1-alpha) quantile of the losses as our starting point for zeta
@@ -648,7 +662,9 @@ def smooth_rockafellar_cvar_regularizer(
     # Instead of max(0, losses - zeta), we use Softplus for a smooth gradient.
     # soft_excess = temp * log(1 + exp((losses - zeta) / temp))
     excess_losses = (losses - zeta)
-    soft_excess = softplus(excess_losses, beta=1/temp)
+    # eps in the denom is redundant here (temp is already validated > 0) but keeps
+    # the expression robust if the validation is ever relaxed.
+    soft_excess = softplus(excess_losses, beta=1.0 / (temp + eps))
     
     # CVaR = zeta + (1 / alpha) * Average(excess_losses)
     # (B,)
@@ -831,6 +847,8 @@ def smooth_omega_objective(
     Returns:
         Tensor: Batch mean smooth omega objective.
     """
+    if beta <= 0:
+        raise ValueError(f"smooth_omega_objective: beta must be > 0, got {beta}")
     # smoothed positive / negative parts
     pos = softplus(pf_returns - theta, beta=beta)      # (R - theta)_+
     neg = softplus(theta - pf_returns, beta=beta)      # (theta - R)_+
@@ -1074,6 +1092,10 @@ def smooth_calmar_objective(
     Returns:
         Tensor: Batch mean smooth calmar ratio.
     """
+    if mdd_temp <= 0:
+        raise ValueError(f"smooth_calmar_objective: mdd_temp must be > 0, got {mdd_temp}")
+    if use_log_loss and beta <= 0:
+        raise ValueError(f"smooth_calmar_objective: beta must be > 0 when use_log_loss=True, got {beta}")
     B, T = pf_returns.shape
 
     # apply theta where requested
@@ -1319,7 +1341,7 @@ def custom_loss_13(
     loss = sharpe + \
         (cvar_lambda * cvar) + \
             (risk_p_lambda * risk_parity) + \
-                (ent_lambda + entropy)
+                (ent_lambda * entropy)
     return loss
 
 @LossLibrary.register(category='custom')
@@ -1338,7 +1360,7 @@ def custom_loss_14(
     loss = omega + \
         (cvar_lambda * cvar) + \
             (risk_p_lambda * risk_parity) + \
-                (ent_lambda + entropy)
+                (ent_lambda * entropy)
     return loss
 
 # @LossLibrary.register(category='custom')
@@ -1362,7 +1384,7 @@ def custom_loss_15(
     loss = sharpe + \
         (cvar_lambda * cvar) + \
             (risk_p_lambda * risk_parity) + \
-                (hhi_lambda + hhi)
+                (hhi_lambda * hhi)
     return loss
 
 # @LossLibrary.register(category='custom')
@@ -1381,5 +1403,5 @@ def custom_loss_16(
     loss = omega + \
         (cvar_lambda * cvar) + \
             (risk_p_lambda * risk_parity) + \
-                (hhi_lambda + hhi)
+                (hhi_lambda * hhi)
     return loss

--- a/financial_loss_functions/src/training/train_nn.py
+++ b/financial_loss_functions/src/training/train_nn.py
@@ -115,6 +115,12 @@ class Trainer:
         self.best_epoch = 0
         self.best_model_state = None
         self.patience_counter = 0
+
+        # Checkpointing state. `resume_start_epoch` is consumed once by train()
+        # and then reset, so multiple calls to train() don't double-skip epochs.
+        self._resume_optimizer_state: dict | None = None
+        self._resume_scheduler_state: dict | None = None
+        self._resume_start_epoch: int = 0
     
     def _cal_pf_returns(self, weights: Tensor, returns: Tensor) -> Tensor:
         """
@@ -173,7 +179,8 @@ class Trainer:
         return scheduler
 
     def train(
-            self, train_ds: WindowDataset, val_ds: WindowDataset | None = None
+            self, train_ds: WindowDataset, val_ds: WindowDataset | None = None,
+            checkpoint_dir: str | None = None,
         ):
         """
         Train initialized model using the train data split.
@@ -181,9 +188,12 @@ class Trainer:
 
         Args:
             train_ds (WindowDataset): Training data split converted to windowed dataset tensors.
-            val_ds (WindowDataset | None): Validation data split for validation during training, 
-                converted to windowed dataset tensors. 
+            val_ds (WindowDataset | None): Validation data split for validation during training,
+                converted to windowed dataset tensors.
                 If None, validation will not be done during training. Default = None.
+            checkpoint_dir (str | None): If provided (and `train_hparams['checkpoint_every']`
+                is > 0), per-epoch checkpoints are written under this directory with the
+                latest-K kept. Default = None (no checkpointing).
         """
         start_time = time.time()
 
@@ -194,18 +204,34 @@ class Trainer:
         min_delta = self.train_hparams.get('early_stop_min_delta', 1e-3)
         early_stopping = self.train_hparams.get('early_stopping', True)
         clip_grad_norm = self.train_hparams.get('clip_grad_norm', 0.5)
-        
+        checkpoint_every = int(self.train_hparams.get('checkpoint_every', 0) or 0)
+        keep_last = int(self.train_hparams.get('checkpoint_keep_last', 3) or 3)
+
         # Initialize optimizer and scheduler
         optimizer = self._init_optimizer()
         scheduler = self._init_scheduler(optimizer)
-        
+
+        # Restore optimizer/scheduler state if a prior checkpoint was loaded via resume_from().
+        if self._resume_optimizer_state is not None:
+            optimizer.load_state_dict(self._resume_optimizer_state)
+            self._resume_optimizer_state = None
+        if self._resume_scheduler_state is not None and scheduler is not None:
+            scheduler.load_state_dict(self._resume_scheduler_state)
+            self._resume_scheduler_state = None
+
+        start_epoch = self._resume_start_epoch
+        self._resume_start_epoch = 0  # consume once so re-calls don't skip
+
+        if checkpoint_dir is not None and checkpoint_every > 0:
+            os.makedirs(checkpoint_dir, exist_ok=True)
+
         train_loader = DataLoader(
             train_ds,
             batch_size=self.train_hparams['train_batch_size'],
             shuffle=True
         )
 
-        for epoch in range(n_epochs):
+        for epoch in range(start_epoch, n_epochs):
             epoch_start = time.time()
             self.model.train()
             total_loss_sum = 0.0
@@ -281,9 +307,15 @@ class Trainer:
                         
                 else:
                     status_msg = status_msg + f' | Val Loss: {avg_val_loss:.5f}'
-            
+
             print(status_msg + f' | Time: {round(time.time() - epoch_start, 3)}s')
-        
+
+            if checkpoint_dir is not None and checkpoint_every > 0 and \
+                    (epoch + 1) % checkpoint_every == 0:
+                self._save_checkpoint(
+                    checkpoint_dir, epoch, optimizer, scheduler, keep_last=keep_last
+                )
+
         # After the training loop
         if self.best_model_state is not None:
             self.model.load_state_dict(self.best_model_state)
@@ -436,6 +468,106 @@ class Trainer:
         elif self.device.type == 'cuda':
             torch.cuda.empty_cache()
             torch.cuda.ipc_collect()
+
+    # ─────────────────── Checkpointing ───────────────────
+
+    @staticmethod
+    def _checkpoint_path(checkpoint_dir: str, epoch: int) -> str:
+        return os.path.join(checkpoint_dir, f'epoch_{epoch:04d}.pt')
+
+    def _save_checkpoint(
+            self,
+            checkpoint_dir: str,
+            epoch: int,
+            optimizer: torch.optim.Optimizer,
+            scheduler,
+            keep_last: int = 3,
+        ) -> str:
+        """
+        Persist {model, optimizer, scheduler, RNG, training state} to disk.
+        Keeps only the most recent `keep_last` checkpoints under checkpoint_dir.
+        """
+        ckpt = {
+            'epoch': epoch,
+            'model_state': self.model.state_dict(),
+            'optimizer_state': optimizer.state_dict(),
+            'scheduler_state': scheduler.state_dict() if scheduler is not None else None,
+            'best_val_loss': self.best_val_loss,
+            'best_train_loss': self.best_train_loss,
+            'best_epoch': self.best_epoch,
+            'best_model_state': self.best_model_state,
+            'patience_counter': self.patience_counter,
+            'train_losses': self.train_losses,
+            'val_losses': self.val_losses,
+            'rng_cpu': torch.get_rng_state(),
+            'rng_cuda': torch.cuda.get_rng_state_all() if torch.cuda.is_available() else None,
+            'rng_numpy': np.random.get_state(),
+        }
+        path = self._checkpoint_path(checkpoint_dir, epoch)
+        # Save atomically: write to a temp path, then rename.
+        tmp_path = path + '.tmp'
+        torch.save(ckpt, tmp_path)
+        os.replace(tmp_path, path)
+        print(f'  ✓ Checkpoint saved: {path}')
+
+        # Prune older checkpoints (keep newest `keep_last`).
+        all_ckpts = sorted(
+            p for p in os.listdir(checkpoint_dir)
+            if p.startswith('epoch_') and p.endswith('.pt')
+        )
+        if keep_last > 0 and len(all_ckpts) > keep_last:
+            for stale in all_ckpts[:-keep_last]:
+                try:
+                    os.remove(os.path.join(checkpoint_dir, stale))
+                except OSError:
+                    pass
+        return path
+
+    def resume_from(self, checkpoint_path: str) -> int:
+        """
+        Restore Trainer state from a checkpoint produced by `_save_checkpoint`.
+
+        Model weights are loaded immediately. Optimizer / scheduler state is
+        staged and applied on the next call to `train()`, since those objects
+        are constructed inside train(). Returns the epoch to resume from.
+        """
+        ckpt = torch.load(checkpoint_path, map_location=self.device, weights_only=False)
+        self.model.load_state_dict(ckpt['model_state'])
+        self._resume_optimizer_state = ckpt.get('optimizer_state')
+        self._resume_scheduler_state = ckpt.get('scheduler_state')
+
+        self.best_val_loss = ckpt.get('best_val_loss', float('inf'))
+        self.best_train_loss = ckpt.get('best_train_loss', float('inf'))
+        self.best_epoch = ckpt.get('best_epoch', 0)
+        self.best_model_state = ckpt.get('best_model_state')
+        self.patience_counter = ckpt.get('patience_counter', 0)
+        self.train_losses = ckpt.get('train_losses', [])
+        self.val_losses = ckpt.get('val_losses', [])
+
+        if 'rng_cpu' in ckpt and ckpt['rng_cpu'] is not None:
+            torch.set_rng_state(ckpt['rng_cpu'])
+        if 'rng_cuda' in ckpt and ckpt['rng_cuda'] is not None and torch.cuda.is_available():
+            torch.cuda.set_rng_state_all(ckpt['rng_cuda'])
+        if 'rng_numpy' in ckpt and ckpt['rng_numpy'] is not None:
+            np.random.set_state(ckpt['rng_numpy'])
+
+        next_epoch = int(ckpt.get('epoch', -1)) + 1
+        self._resume_start_epoch = next_epoch
+        print(f'Resumed from {checkpoint_path} — next epoch = {next_epoch}')
+        return next_epoch
+
+    @staticmethod
+    def find_latest_checkpoint(checkpoint_dir: str) -> str | None:
+        """Return the path to the highest-epoch checkpoint under dir, or None."""
+        if not os.path.isdir(checkpoint_dir):
+            return None
+        ckpts = sorted(
+            p for p in os.listdir(checkpoint_dir)
+            if p.startswith('epoch_') and p.endswith('.pt')
+        )
+        if not ckpts:
+            return None
+        return os.path.join(checkpoint_dir, ckpts[-1])
 
 class Walker:
 

--- a/financial_loss_functions/tests/unit/training/test_loss_functions.py
+++ b/financial_loss_functions/tests/unit/training/test_loss_functions.py
@@ -1,0 +1,240 @@
+"""
+Unit tests for financial loss functions.
+
+Tests are registry-driven: every loss in LossLibrary gets shape, gradient, and
+finite-output checks automatically. Targeted tests cover numerical-stability
+fixes (near-`-1` returns through log-based losses, non-positive temp/beta) and
+sign/monotonicity on a handful of representative functions.
+"""
+from __future__ import annotations
+
+import inspect
+import math
+from typing import Callable
+
+import pytest
+import torch
+
+from src.training.loss_functions import LossLibrary
+
+torch.manual_seed(0)
+
+
+# ───────────────────────── helpers ─────────────────────────
+
+def _sample_batch(
+    B: int = 4, T: int = 16, N: int = 5, seed: int = 123
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Create (logits, weights, all_returns, pf_returns). `logits` is the leaf."""
+    g = torch.Generator().manual_seed(seed)
+    logits = torch.randn(B, N, generator=g, requires_grad=True)
+    weights = torch.softmax(logits, dim=-1)
+
+    all_returns = 0.01 * torch.randn(B, T, N, generator=g)
+    pf_returns = (weights.unsqueeze(1) * all_returns).sum(dim=-1)
+    return logits, weights, all_returns, pf_returns
+
+
+def _call_loss(fn: Callable, weights, all_returns, pf_returns) -> torch.Tensor:
+    """Call a registered loss with whichever of the three tensors it accepts."""
+    params = inspect.signature(fn).parameters
+    kwargs: dict = {}
+    if "weights" in params:
+        kwargs["weights"] = weights
+    # `all_returns` vs `returns` naming differs across functions.
+    if "all_returns" in params:
+        kwargs["all_returns"] = all_returns
+    elif "returns" in params:
+        kwargs["returns"] = all_returns
+    # Most losses name the portfolio-return tensor `pf_returns`;
+    # `log_return_objective` uses `port_returns`.
+    if "pf_returns" in params:
+        kwargs["pf_returns"] = pf_returns
+    elif "port_returns" in params:
+        kwargs["port_returns"] = pf_returns
+    # Composites that require lambdas.
+    for lam in (
+        "lambda1", "lambda2", "cvar_lambda", "risk_p_lambda",
+        "ent_lambda", "hhi_lambda", "log_ret_lambda",
+    ):
+        if lam in params and lam not in kwargs:
+            kwargs[lam] = 0.1
+    return fn(**kwargs)
+
+
+def _collect_registered_losses() -> list[tuple[str, str, str, Callable]]:
+    """Flatten LossLibrary registry into (category, subcategory, name, fn) tuples."""
+    out = []
+    for cat, subs in LossLibrary.items().items():
+        for sub, fns in subs.items():
+            for name, fn in fns.items():
+                out.append((cat, sub, name, fn))
+    return out
+
+
+ALL_LOSSES = _collect_registered_losses()
+ALL_LOSS_IDS = [f"{c}/{s}/{n}" for c, s, n, _ in ALL_LOSSES]
+
+
+# ───────────────────────── registry-driven tests ─────────────────────────
+
+@pytest.mark.parametrize(("cat", "sub", "name", "fn"), ALL_LOSSES, ids=ALL_LOSS_IDS)
+def test_loss_returns_scalar(cat, sub, name, fn):
+    logits, weights, all_returns, pf_returns = _sample_batch()
+    out = _call_loss(fn, weights, all_returns, pf_returns)
+    assert isinstance(out, torch.Tensor), f"{name}: expected Tensor, got {type(out)}"
+    assert out.dim() == 0, f"{name}: expected scalar, got shape {tuple(out.shape)}"
+
+
+@pytest.mark.parametrize(("cat", "sub", "name", "fn"), ALL_LOSSES, ids=ALL_LOSS_IDS)
+def test_loss_is_finite(cat, sub, name, fn):
+    logits, weights, all_returns, pf_returns = _sample_batch()
+    out = _call_loss(fn, weights, all_returns, pf_returns)
+    assert torch.isfinite(out).item(), f"{name}: non-finite output {out.item()}"
+
+
+@pytest.mark.parametrize(("cat", "sub", "name", "fn"), ALL_LOSSES, ids=ALL_LOSS_IDS)
+def test_loss_backward_produces_finite_grads(cat, sub, name, fn):
+    logits, weights, all_returns, pf_returns = _sample_batch()
+    out = _call_loss(fn, weights, all_returns, pf_returns)
+    out.backward()
+    # `logits` is the leaf upstream of weights/pf_returns.
+    assert logits.grad is not None, f"{name}: no grad flowed to logits"
+    assert torch.isfinite(logits.grad).all().item(), f"{name}: non-finite logit grads"
+
+
+# ───────────────────────── numerical-stability regressions ─────────────────────────
+
+# These correspond to the log(1+r) clamp fix (#2). With returns near -1 the old
+# code produced log(≈0) and NaN/-inf; the new code must stay finite.
+
+LOG_BASED_LOSSES = [
+    ("log_return_objective", {}),
+    ("log_sharpe_objective", {}),
+    ("log_sortino_objective", {}),
+]
+
+
+@pytest.mark.parametrize(("loss_name", "extra_kwargs"), LOG_BASED_LOSSES)
+def test_log_losses_handle_returns_near_negative_one(loss_name, extra_kwargs):
+    """
+    Regression for the log(1+r) clamp fix (#2). Before the fix, returns at or
+    below `-1 - eps` produced log(<=0) → NaN. After the fix the output must be
+    finite. (Gradient finiteness through var.sqrt() is not tested here; that's
+    a separate Sharpe-variance issue unrelated to this bugfix.)
+    """
+    fn = LossLibrary.get("objectives", loss_name)
+    B, T = 2, 8
+    # Catastrophic window with tiny jitter so downstream var() > 0.
+    base = torch.full((B, T), -0.999)
+    jitter = 1e-5 * torch.randn(B, T)
+    pf = (base + jitter).detach().requires_grad_(True)
+    params = inspect.signature(fn).parameters
+    kw = dict(extra_kwargs)
+    kw["port_returns" if "port_returns" in params else "pf_returns"] = pf
+    out = fn(**kw)
+    assert torch.isfinite(out).item(), f"{loss_name}: not finite on -0.999 returns"
+
+
+# These correspond to the temp/beta validation (#3). Bad configs must raise.
+
+BAD_TEMP_BETA_CASES = [
+    ("objectives",       "smooth_neglog_sharpe_loss",           {"beta": 0.0}),
+    ("objectives",       "smooth_neglog_sortino_objective",     {"beta": 0.0}),
+    ("objectives",       "smooth_omega_objective",              {"beta": -1.0}),
+    ("objectives",       "log_sortino_objective",               {"beta": 0.0}),
+    ("objectives",       "smooth_calmar_objective",             {"mdd_temp": 0.0}),
+    ("regularizers",     "smooth_mdd_regularizer",              {"temp": 0.0}),
+    ("regularizers",     "smooth_cvar_regularizer",             {"temp": 0.0}),
+    ("regularizers",     "smooth_rockafellar_cvar_regularizer", {"temp": -0.1}),
+]
+
+
+@pytest.mark.parametrize(("cat", "name", "bad_kwargs"), BAD_TEMP_BETA_CASES)
+def test_bad_temp_beta_raise(cat, name, bad_kwargs):
+    # Tail-risk regularizers live under a subcategory.
+    subcategory = "tail_risk" if name in (
+        "smooth_mdd_regularizer",
+        "smooth_cvar_regularizer",
+        "smooth_rockafellar_cvar_regularizer",
+    ) else None
+    fn = LossLibrary.get(cat, name, subcategory=subcategory)
+    _, _, _, pf_returns = _sample_batch()
+    with pytest.raises(ValueError):
+        fn(pf_returns=pf_returns, **bad_kwargs)
+
+
+# ───────────────────────── targeted semantic checks ─────────────────────────
+
+def test_log_return_monotonic_in_mean():
+    """Higher mean returns → lower (more negative) loss."""
+    fn = LossLibrary.get("objectives", "log_return_objective")
+    low = fn(port_returns=torch.full((2, 10), 0.001))
+    high = fn(port_returns=torch.full((2, 10), 0.01))
+    assert high.item() < low.item(), "log_return_objective not decreasing in mean return"
+
+
+def test_raw_sharpe_zero_variance_is_finite():
+    """Constant non-zero returns produce zero variance; the eps floor keeps things finite."""
+    fn = LossLibrary.get("objectives", "raw_sharpe_objective")
+    pf_returns = torch.full((2, 8), 0.005)
+    out = fn(pf_returns=pf_returns)
+    assert torch.isfinite(out).item()
+
+
+def test_hhi_uniform_weights_is_zero_when_scaled():
+    fn = LossLibrary.get("regularizers", "hhi_regularizer", subcategory="structural")
+    N = 10
+    weights = torch.full((3, N), 1.0 / N)
+    out = fn(weights=weights, scale_to_unit=True)
+    assert out.item() == pytest.approx(0.0, abs=1e-6)
+
+
+def test_hhi_concentrated_weights_is_one_when_scaled():
+    fn = LossLibrary.get("regularizers", "hhi_regularizer", subcategory="structural")
+    weights = torch.zeros(2, 5)
+    weights[:, 0] = 1.0  # all in one asset
+    out = fn(weights=weights, scale_to_unit=True)
+    assert out.item() == pytest.approx(1.0, abs=1e-6)
+
+
+def test_entropy_scaled_uniform_is_zero():
+    fn = LossLibrary.get("regularizers", "entropy_conc_regularizer", subcategory="structural")
+    N = 8
+    weights = torch.full((4, N), 1.0 / N)
+    out = fn(weights=weights, mode="scaled")
+    assert out.item() == pytest.approx(0.0, abs=1e-5)
+
+
+def test_cvar_topk_matches_empirical_mean():
+    """CVaR via top-k should average the worst ceil(alpha*T) losses."""
+    fn = LossLibrary.get("regularizers", "cvar_topk_regularizer", subcategory="tail_risk")
+    pf_returns = torch.tensor([[0.01, -0.02, 0.03, -0.05, 0.00, 0.02, -0.01, 0.04]])
+    alpha = 0.25  # worst 2 out of 8
+    out = fn(pf_returns=pf_returns, alpha=alpha).item()
+    expected = (0.05 + 0.02) / 2  # the two largest losses (= -returns)
+    assert out == pytest.approx(expected, abs=1e-6)
+
+
+def test_custom_loss_13_uses_multiplied_entropy_term():
+    """
+    Regression for the `+ → *` fix (#1). When ent_lambda = 0, the entropy term
+    must drop out entirely. Two runs with different ent_lambda (0 vs non-zero)
+    and identical other lambdas must therefore differ by exactly
+    `(lam_b - lam_a) * entropy_term` — which only holds with multiplication.
+    """
+    fn = LossLibrary.get("custom", "custom_loss_13")
+    logits, weights, all_returns, pf_returns = _sample_batch()
+    base_kwargs = dict(
+        weights=weights, all_returns=all_returns, pf_returns=pf_returns,
+        cvar_lambda=0.1, risk_p_lambda=0.1,
+    )
+    a = fn(**base_kwargs, ent_lambda=0.0).item()
+    b = fn(**base_kwargs, ent_lambda=0.5).item()
+
+    # With multiplication the contribution is lam * entropy_term. With addition
+    # it would have been just `lam` added on. So b - a ≠ 0.5 is the test.
+    assert not math.isclose(b - a, 0.5, abs_tol=1e-6), (
+        "custom_loss_13 behaves as if entropy term is ADDED with lambda "
+        "(the original bug) instead of multiplied."
+    )


### PR DESCRIPTION
## Summary

- **Correctness (loss_functions.py):** fix `+` vs `*` typo in `custom_loss_13/14/15/16` (entropy and HHI were added to their lambdas instead of scaled by them); clamp `1 + r` to `>= eps` in `log_return / log_sharpe / log_sortino` so returns near `-1` don't produce non-positive log args; validate `temp`/`beta > 0` at entry of every softplus-based loss and eps-floor the `beta = 1/temp` in Rockafellar CVaR.
- **Tests:** new `tests/unit/training/test_loss_functions.py` (99 cases) — registry-driven shape/finiteness/gradient coverage for every registered loss, plus targeted regressions for each fix and semantic checks (HHI uniform=0 / concentrated=1, CVaR top-k matches empirical tail mean, log-return monotonicity).
- **Evaluation:** add `MinVarianceCalculator` (long-only QP via cvxopt, optional linear shrinkage) and `EqualRiskContribCalculator` (Maillard-Roncalli-Teiletche fixed point); add stationary-block bootstrap helpers `bootstrap_metric_ci` and `bootstrap_paired_diff_ci`, exposed via `Evaluator.calc_metric_performance_ci` and `calc_paired_diff_ci`; register `turnover` in `MetricLibrary` and add `Evaluator.calc_turnover_for_all` and `calc_cost_adjusted_daily_rets`.
- **Training robustness:** `Trainer` now supports periodic checkpointing (controlled by `train_hparams.checkpoint_every` and `checkpoint_keep_last`) persisting model, optimizer, scheduler, RNG, and early-stopping state atomically; new `Trainer.resume_from()` and `find_latest_checkpoint()`; `scripts/run_multi_train.py` accepts `--resume` and writes per-seed checkpoints under `artifacts/results/checkpoints/<combo-seed>/`.

## Test plan

- [x] `pytest tests/unit/training/test_loss_functions.py` — 99 / 99 pass
- [x] Full `pytest tests/unit` — 306 pass; 5 pre-existing failures on `main` (unrelated: `test_loading.py`, `test_io.py`)
- [x] Smoke-tested `MinVarianceCalculator` + `EqualRiskContribCalculator` on synthetic returns — weights sum to 1, long-only, ERC risk contributions equal to ~1e-6
- [x] Smoke-tested bootstrap CI + paired diff + `calc_metric_performance_ci` on synthetic data
- [x] Smoke-tested `Evaluator.calc_turnover_for_all` and `calc_cost_adjusted_daily_rets` — turnover in `[0, 1]`, cost-adjusted mean < gross mean
- [x] Smoke-tested `Trainer` checkpoint/resume: 4-epoch run → kill → resume from epoch 4 → 2 more epochs; loss continues decreasing across the boundary, oldest checkpoint pruned per `keep_last`
- [ ] Re-run a real `scripts.run_multi_train` grid once dependencies (`statsmodels` etc.) are installed on the target env